### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "morgan": "^1.7.0",
     "multer": "^1.2.0",
     "node-pre-gyp": "*",
-    "node-uuid": "^1.4.3",
     "nodejs-config": "^1.0.1",
     "nodejs-leds": "0.0.3",
     "nodejs-websocket": "^1.4.0",
@@ -98,7 +97,7 @@
     "throttle": "^1.0.3",
     "underscore": "^1.8.2",
     "utils-debug": "^0.6.3",
-    "uuid": "^2.0.3",
+    "uuid": "^3.0.0",
     "waterline": "^0.11.4",
     "winston": "^2.2.0"
   },

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -3,7 +3,7 @@
  *	Copyright (c) 2015, All rights reserved, http://printr.nl
  */
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 module.exports =
 {	

--- a/src/modules/cloud/index.js
+++ b/src/modules/cloud/index.js
@@ -13,7 +13,7 @@ const path		 = require('path');
 const publicIp	 = require('public-ip');
 const request	 = require('request');
 const socket	 = require('socket.io-client');
-const uuid		 = require('node-uuid');
+const uuid		 = require('uuid');
 const Throttle   = require('throttle');
 
 module.exports = {

--- a/src/modules/db/rest/printjob.js
+++ b/src/modules/db/rest/printjob.js
@@ -8,7 +8,7 @@
 const assert = require('assert');
 const fs	 = require('fs-extra');
 const path   = require('path');
-const uuid   = require('node-uuid');
+const uuid   = require('uuid');
 
 module.exports = (routes, db) => {
 

--- a/src/modules/db/rest/userfile.js
+++ b/src/modules/db/rest/userfile.js
@@ -10,7 +10,7 @@ const path   = require('path');
 const fs     = require('fs');
 const co     = require('co');
 const stream = require('stream');
-const uuid   = require('node-uuid');
+const uuid   = require('uuid');
 const base64 = require('base64-stream');
 const assert = require('assert');
 

--- a/src/modules/files/index.js
+++ b/src/modules/files/index.js
@@ -7,7 +7,7 @@
 
 const fs		   = require('fs');
 const path		   = require('path');
-const uuid		   = require('node-uuid');
+const uuid		   = require('uuid');
 const diskspace	   = require('diskspace');
 const SPACE_BUFFER = 1000000; // 1MB
 const MAX_STL_SIZE = 20000000; // 20MB, to prevent slicer crashing

--- a/src/modules/slicer/index.js
+++ b/src/modules/slicer/index.js
@@ -5,7 +5,7 @@
 
 // dependencies
 const fs 		   = require('fs');
-const uuid 		   = require('node-uuid');
+const uuid 		   = require('uuid');
 const formideTools = require('katana-tools');
 const diskspace	   = require('diskspace');
 const assert	   = require('assert');

--- a/src/utils/db/models/accesstoken.js
+++ b/src/utils/db/models/accesstoken.js
@@ -3,7 +3,7 @@
  *	Copyright (c) 2015, All rights reserved, http://printr.nl
  */
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 module.exports = {
 	identity: 'accesstoken',

--- a/src/utils/db/models/log.js
+++ b/src/utils/db/models/log.js
@@ -3,7 +3,7 @@
  *	Copyright (c) 2015, All rights reserved, http://printr.nl
  */
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 module.exports = {
 	identity: 'log',

--- a/src/utils/db/seed.js
+++ b/src/utils/db/seed.js
@@ -3,7 +3,7 @@
 const fs      = require('fs');
 const co      = require('co');
 const path    = require('path');
-const uuid    = require('node-uuid');
+const uuid    = require('uuid');
 const thenify = require('thenify');
 const readdir = thenify(fs.readdir);
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.